### PR TITLE
fix: allow for linux builds with gcc/clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,8 @@ endif()
 
 # Link to the actual SDL2 library. SDL2::SDL2 is the shared SDL library, SDL2::SDL2-static is the static SDL libarary.
 target_link_libraries(flappybird PRIVATE SDL2::SDL2 SDL2_image::SDL2_image SDL2_mixer::SDL2_mixer)
+
+find_library(MATH_LIBRARY m)
+if (MATH_LIBRARY)
+    target_link_libraries(flappybird PRIVATE ${MATH_LIBRARY})
+endif()

--- a/flappybird.c
+++ b/flappybird.c
@@ -141,7 +141,7 @@ typedef struct pipe {
     float gap_y;
 } pipe;
 
-const int Max_Pipes = 10;
+#define   Max_Pipes 10
 pipe      pipes[Max_Pipes];
 int       pipes_len = 0;
 int       pipe_to_pass = 0;
@@ -164,7 +164,7 @@ int get_sprite_height(const SDL_Rect *rect) {
 }
 
 SDL_Thread   *save_thread;
-const size_t  Save_File_Path_Len = 256;
+#define       Save_File_Path_Len 256
 char          save_file_path[Save_File_Path_Len];
 
 int load_file() {
@@ -191,7 +191,7 @@ int load_file() {
     return 0;
 }
 
-const size_t Save_File_Err_Len = 128;
+#define      Save_File_Err_Len 128
 char         save_file_err[Save_File_Err_Len];
 
 typedef enum user_codes_t {


### PR DESCRIPTION
This fixes the build with Linux. The problems were:
1. Compiler errors when using const variables as array sizes.
2. Not explicitly linking with the C math library.

Tested with gcc/clang.

